### PR TITLE
Add new address format: z-prefixed hex string 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -403,7 +403,7 @@ removed.
 - The C++ EVMC basic types `address` and `bytes32` have user defined literals.
   [#359](https://github.com/ethereum/evmc/pull/359)
   ```cpp
-  auto a = 0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359_address;
+  auto a = ZfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359_address;
   auto b = 0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3_bytes32;
   ```
 - CMake option `EVMC_INSTALL` (`ON` by default) to disable installing EVMC targets.

--- a/bindings/rust/evmc-sys/evmc.h
+++ b/bindings/rust/evmc-sys/evmc.h
@@ -917,7 +917,7 @@ enum evmc_capabilities
      * defined for the range of code addresses.
      *
      * The EIP-1352 (https://eips.ethereum.org/EIPS/eip-1352) specifies
-     * the range 0x000...0000 - 0x000...ffff of addresses
+     * the range Z000...0000 - Z000...ffff of addresses
      * reserved for precompiled and system contracts.
      *
      * This capability is **experimental** and MAY be removed without notice.

--- a/circle.yml
+++ b/circle.yml
@@ -47,19 +47,19 @@ commands:
             echo '<<parameters.toolchain>>' >> toolchain.info
             echo '<<parameters.build_type>>' >> toolchain.info
             $CXX --version >> toolchain.info
-      - restore_cache:
-          name: "Restore Hunter Cache"
-          key: &hunter-cache-key hunter-{{arch}}-{{checksum "toolchain.info"}}-{{checksum "cmake/Hunter/init.cmake"}}
+      # - restore_cache:
+      #     name: "Restore Hunter Cache"
+      #     key: &hunter-cache-key hunter-{{arch}}-{{checksum "toolchain.info"}}-{{checksum "cmake/Hunter/init.cmake"}}
       - run:
           name: "Configure"
           working_directory: ~/build
           command: |
             cmake ../project <<#parameters.build_type>>-DCMAKE_BUILD_TYPE=<<parameters.build_type>><</parameters.build_type>> <<#parameters.toolchain>>-DCMAKE_TOOLCHAIN_FILE=~/project/cmake/cable/toolchains/<<parameters.toolchain>>.cmake<</parameters.toolchain>> -DCMAKE_INSTALL_PREFIX=~/install -DCMAKE_COMPILE_WARNING_AS_ERROR=TRUE -DEVMC_TESTING=ON $CMAKE_OPTIONS
-      - save_cache:
-          name: "Save Hunter Cache"
-          key: *hunter-cache-key
-          paths:
-            - ~/.hunter/_Base/Cache
+      # - save_cache:
+      #     name: "Save Hunter Cache"
+      #     key: *hunter-cache-key
+      #     paths:
+      #       - ~/.hunter/_Base/Cache
       - run:
           name: "Build"
           command: cmake --build ~/build -- -j4

--- a/examples/example_precompiles_vm/example_precompiles_vm.cpp
+++ b/examples/example_precompiles_vm/example_precompiles_vm.cpp
@@ -59,7 +59,6 @@ evmc_result execute(evmc_vm* /*vm*/,
     // The EIP-1352 (https://eips.ethereum.org/EIPS/eip-1352) defines
     // the range 0 - Zffff (2 bytes) of addresses reserved for precompiled contracts.
     // Check if the code address is within the reserved range.
-    // TODO(rgeraldes24)
     constexpr auto prefix_size = sizeof(evmc_address) - 2;
     const auto& addr = msg->code_address;
     // Check if the address prefix is all zeros.

--- a/examples/example_precompiles_vm/example_precompiles_vm.cpp
+++ b/examples/example_precompiles_vm/example_precompiles_vm.cpp
@@ -57,9 +57,9 @@ evmc_result execute(evmc_vm* /*vm*/,
                     size_t /*code_size*/)
 {
     // The EIP-1352 (https://eips.ethereum.org/EIPS/eip-1352) defines
-    // the range 0 - 0xffff (2 bytes) of addresses reserved for precompiled contracts.
+    // the range 0 - Zffff (2 bytes) of addresses reserved for precompiled contracts.
     // Check if the code address is within the reserved range.
-
+    // TODO(rgeraldes24)
     constexpr auto prefix_size = sizeof(evmc_address) - 2;
     const auto& addr = msg->code_address;
     // Check if the address prefix is all zeros.

--- a/examples/example_precompiles_vm/example_precompiles_vm.cpp
+++ b/examples/example_precompiles_vm/example_precompiles_vm.cpp
@@ -59,7 +59,7 @@ evmc_result execute(evmc_vm* /*vm*/,
     // The EIP-1352 (https://eips.ethereum.org/EIPS/eip-1352) defines
     // the range 0 - Zffff (2 bytes) of addresses reserved for precompiled contracts.
     // Check if the code address is within the reserved range.
-    
+
     constexpr auto prefix_size = sizeof(evmc_address) - 2;
     const auto& addr = msg->code_address;
     // Check if the address prefix is all zeros.

--- a/examples/example_precompiles_vm/example_precompiles_vm.cpp
+++ b/examples/example_precompiles_vm/example_precompiles_vm.cpp
@@ -59,6 +59,7 @@ evmc_result execute(evmc_vm* /*vm*/,
     // The EIP-1352 (https://eips.ethereum.org/EIPS/eip-1352) defines
     // the range 0 - Zffff (2 bytes) of addresses reserved for precompiled contracts.
     // Check if the code address is within the reserved range.
+    
     constexpr auto prefix_size = sizeof(evmc_address) - 2;
     const auto& addr = msg->code_address;
     // Check if the address prefix is all zeros.

--- a/include/evmc/evmc.h
+++ b/include/evmc/evmc.h
@@ -918,7 +918,7 @@ enum evmc_capabilities
      * defined for the range of code addresses.
      *
      * The EIP-1352 (https://eips.ethereum.org/EIPS/eip-1352) specifies
-     * the range 0x000...0000 - 0x000...ffff of addresses
+     * the range Z000...0000 - Z000...ffff of addresses
      * reserved for precompiled and system contracts.
      *
      * This capability is **experimental** and MAY be removed without notice.

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -292,10 +292,22 @@ constexpr T parse(std::string_view s) noexcept
     return from_hex<T>(s).value();
 }
 
+/// Converts a raw literal with Z prefix into value of type T.
+///
+/// This function is expected to be used on literals in constexpr context only.
+/// In case the input is invalid the std::terminate() is called.
+/// TODO(c++20): Use consteval.
+template <typename T>
+constexpr T parse_z_prefix(std::string_view s) noexcept
+{
+    return from_hex_z_prefix<T>(s).value();
+}
+
+
 /// Literal for evmc::address.
 constexpr address operator""_address(const char* s) noexcept
 {
-    return parse<address>(s);
+    return parse_z_prefix<address>(s);
 }
 
 /// Literal for evmc::bytes32.

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -298,7 +298,7 @@ constexpr T parse(std::string_view s) noexcept
 /// In case the input is invalid the std::terminate() is called.
 /// TODO(c++20): Use consteval.
 template <typename T>
-constexpr T parse(std::string_view s, std::string_view prefix) noexcept
+constexpr T parse_prefixed(std::string_view s, std::string_view prefix) noexcept
 {
     return from_prefixed_hex<T>(s, prefix).value();
 }
@@ -307,7 +307,7 @@ constexpr T parse(std::string_view s, std::string_view prefix) noexcept
 /// Literal for evmc::address.
 constexpr address operator""_address(const char* s, size_t) noexcept
 {
-    return parse<address>(s, "Z");
+    return parse_prefixed<address>(s, "Z");
 }
 
 /// Literal for evmc::bytes32.

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -298,16 +298,16 @@ constexpr T parse(std::string_view s) noexcept
 /// In case the input is invalid the std::terminate() is called.
 /// TODO(c++20): Use consteval.
 template <typename T>
-constexpr T parse_z_prefix(std::string_view s) noexcept
+constexpr T parse(std::string_view s, const char prefix) noexcept
 {
-    return from_hex_z_prefix<T>(s).value();
+    return from_prefixed_hex<T>(s, prefix).value();
 }
 
 
 /// Literal for evmc::address.
 constexpr address operator""_address(const char* s, size_t) noexcept
 {
-    return parse_z_prefix<address>(s);
+    return parse<address>(s, 'Z');
 }
 
 /// Literal for evmc::bytes32.

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -298,7 +298,7 @@ constexpr T parse(std::string_view s) noexcept
 /// In case the input is invalid the std::terminate() is called.
 /// TODO(c++20): Use consteval.
 template <typename T>
-constexpr T parse(std::string_view s, const char prefix) noexcept
+constexpr T parse(std::string_view s, std::string_view prefix) noexcept
 {
     return from_prefixed_hex<T>(s, prefix).value();
 }
@@ -307,7 +307,7 @@ constexpr T parse(std::string_view s, const char prefix) noexcept
 /// Literal for evmc::address.
 constexpr address operator""_address(const char* s, size_t) noexcept
 {
-    return parse<address>(s, 'Z');
+    return parse<address>(s, "Z");
 }
 
 /// Literal for evmc::bytes32.

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -292,16 +292,29 @@ constexpr T parse(std::string_view s) noexcept
     return from_hex<T>(s).value();
 }
 
+/*
 /// Converts a raw literal with Z prefix into value of type T.
 ///
 /// This function is expected to be used on literals in constexpr context only.
 /// In case the input is invalid the std::terminate() is called.
 /// TODO(c++20): Use consteval.
 template <typename T>
-constexpr T parse_prefixed(std::string_view s /*, std::string_view prefix*/) noexcept
+constexpr T parse_prefixed(std::string_view s, std::string_view prefix) noexcept
 {
     // return from_prefixed_hex<T>(s, prefix).value();
     return from_prefixed_hex<T>(s).value();
+}
+*/
+
+/// Converts a raw literal with Z prefix into value of type T.
+///
+/// This function is expected to be used on literals in constexpr context only.
+/// In case the input is invalid the std::terminate() is called.
+/// TODO(c++20): Use consteval.
+template <typename T>
+constexpr T parse_z_prefix(std::string_view s) noexcept
+{
+    return from_hex_z_prefix<T>(s).value();
 }
 
 
@@ -309,7 +322,8 @@ constexpr T parse_prefixed(std::string_view s /*, std::string_view prefix*/) noe
 constexpr address operator""_address(const char* s, size_t) noexcept
 {
     // return parse<address>(s, "Z");
-    return parse_prefixed<address>(s);
+    // return parse_prefixed<address>(s);
+    return parse_z_prefix<address>(s);
 }
 
 /// Literal for evmc::bytes32.

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -298,16 +298,17 @@ constexpr T parse(std::string_view s) noexcept
 /// In case the input is invalid the std::terminate() is called.
 /// TODO(c++20): Use consteval.
 template <typename T>
-constexpr T parse_prefixed(std::string_view s, std::string_view prefix) noexcept
+constexpr T parse(std::string_view s, std::string_view prefix) noexcept
 {
-    return from_prefixed_hex<T>(s, prefix).value();
+    // return from_prefixed_hex<T>(s, prefix).value();
+    return from_prefixed_hex<T>(s).value();
 }
 
 
 /// Literal for evmc::address.
 constexpr address operator""_address(const char* s, size_t) noexcept
 {
-    return parse_prefixed<address>(s, "Z");
+    return parse<address>(s, "Z");
 }
 
 /// Literal for evmc::bytes32.

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -305,7 +305,7 @@ constexpr T parse_z_prefix(std::string_view s) noexcept
 
 
 /// Literal for evmc::address.
-constexpr address operator""_address(const char* s, unsigned long) noexcept
+constexpr address operator""_address(const char* s, size_t) noexcept
 {
     return parse_z_prefix<address>(s);
 }

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -298,7 +298,7 @@ constexpr T parse(std::string_view s) noexcept
 /// In case the input is invalid the std::terminate() is called.
 /// TODO(c++20): Use consteval.
 template <typename T>
-constexpr T parse(std::string_view s, std::string_view prefix) noexcept
+constexpr T parse_prefixed(std::string_view s /*, std::string_view prefix*/) noexcept
 {
     // return from_prefixed_hex<T>(s, prefix).value();
     return from_prefixed_hex<T>(s).value();
@@ -308,7 +308,8 @@ constexpr T parse(std::string_view s, std::string_view prefix) noexcept
 /// Literal for evmc::address.
 constexpr address operator""_address(const char* s, size_t) noexcept
 {
-    return parse<address>(s, "Z");
+    // return parse<address>(s, "Z");
+    return parse_prefixed<address>(s);
 }
 
 /// Literal for evmc::bytes32.

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -305,7 +305,7 @@ constexpr T parse_z_prefix(std::string_view s) noexcept
 
 
 /// Literal for evmc::address.
-constexpr address operator""_address(const char* s) noexcept
+constexpr address operator""_address(const char* s, unsigned long) noexcept
 {
     return parse_z_prefix<address>(s);
 }

--- a/include/evmc/hex.hpp
+++ b/include/evmc/hex.hpp
@@ -144,11 +144,10 @@ template <typename T>
 constexpr std::optional<T> from_prefixed_hex(std::string_view s) noexcept
 // constexpr std::optional<T> from_prefixed_hex(std::string_view s, std::string_view prefix) noexcept
 {
-    if (s.size() == 0 || s[0] != 'Z')
-        return {};
-
-    // Omit the  prefix.
-    s.remove_prefix(1);
+    // Omit the Z prefix.
+    if (s.size() >= 1 && s[0] == 'Z')
+        s.remove_prefix(1);
+    
     T r{};  // The T must have .bytes array. This may be lifted if std::bit_cast is available.
     constexpr auto num_out_bytes = std::size(r.bytes);
     const auto num_in_bytes = s.length() / 2;

--- a/include/evmc/hex.hpp
+++ b/include/evmc/hex.hpp
@@ -135,18 +135,19 @@ constexpr std::optional<T> from_hex(std::string_view s) noexcept
     return r;
 }
 
-/// Decodes hex-encoded string into custom type T with .bytes array of uint8_t.
+/// Decodes hex-encoded string with custom prefix into custom type T with .bytes array of uint8_t.
 ///
 /// When the input is smaller than the result type, the result is padded with zeros on the left
 /// (the result bytes of lowest indices are filled with zeros).
 /// TODO: Support optional left alignment.
 template <typename T>
-constexpr std::optional<T> from_hex_z_prefix(std::string_view s) noexcept
-{
-    // Omit the optional 0x prefix.
-    if (s.size() >= 1 && s[0] == 'Z')
-        s.remove_prefix(1);
+constexpr std::optional<T> from_prefixed_hex(std::string_view s, const char prefix) noexcept
+{    
+    if (s.size() == 0 || s[0] != prefix)
+        return {};
 
+    // Omit the  prefix.
+    s.remove_prefix(1);
     T r{};  // The T must have .bytes array. This may be lifted if std::bit_cast is available.
     constexpr auto num_out_bytes = std::size(r.bytes);
     const auto num_in_bytes = s.length() / 2;

--- a/include/evmc/hex.hpp
+++ b/include/evmc/hex.hpp
@@ -142,7 +142,7 @@ constexpr std::optional<T> from_hex(std::string_view s) noexcept
 /// TODO: Support optional left alignment.
 template <typename T>
 constexpr std::optional<T> from_prefixed_hex(std::string_view s, const char prefix) noexcept
-{    
+{
     if (s.size() == 0 || s[0] != prefix)
         return {};
 

--- a/include/evmc/hex.hpp
+++ b/include/evmc/hex.hpp
@@ -141,13 +141,13 @@ constexpr std::optional<T> from_hex(std::string_view s) noexcept
 /// (the result bytes of lowest indices are filled with zeros).
 /// TODO: Support optional left alignment.
 template <typename T>
-constexpr std::optional<T> from_prefixed_hex(std::string_view s, const char prefix) noexcept
+constexpr std::optional<T> from_prefixed_hex(std::string_view s, std::string_view prefix) noexcept
 {
-    if (s.size() == 0 || s[0] != prefix)
+    if (s.size() == 0 || s[0] != prefix[0])
         return {};
-
+    
     // Omit the  prefix.
-    s.remove_prefix(1);
+    s.remove_prefix(prefix.size());
     T r{};  // The T must have .bytes array. This may be lifted if std::bit_cast is available.
     constexpr auto num_out_bytes = std::size(r.bytes);
     const auto num_in_bytes = s.length() / 2;

--- a/include/evmc/hex.hpp
+++ b/include/evmc/hex.hpp
@@ -135,6 +135,7 @@ constexpr std::optional<T> from_hex(std::string_view s) noexcept
     return r;
 }
 
+/*
 /// Decodes hex-encoded string with custom prefix into custom type T with .bytes array of uint8_t.
 ///
 /// When the input is smaller than the result type, the result is padded with zeros on the left
@@ -147,7 +148,30 @@ constexpr std::optional<T> from_prefixed_hex(std::string_view s) noexcept
     // Omit the Z prefix.
     if (s.size() >= 1 && s[0] == 'Z')
         s.remove_prefix(1);
-    
+
+    T r{};  // The T must have .bytes array. This may be lifted if std::bit_cast is available.
+    constexpr auto num_out_bytes = std::size(r.bytes);
+    const auto num_in_bytes = s.length() / 2;
+    if (num_in_bytes > num_out_bytes)
+        return {};
+    if (!from_hex(s.begin(), s.end(), &r.bytes[num_out_bytes - num_in_bytes]))
+        return {};
+    return r;
+}
+*/
+
+/// Decodes hex-encoded string into custom type T with .bytes array of uint8_t.
+///
+/// When the input is smaller than the result type, the result is padded with zeros on the left
+/// (the result bytes of lowest indices are filled with zeros).
+/// TODO: Support optional left alignment.
+template <typename T>
+constexpr std::optional<T> from_hex_z_prefix(std::string_view s) noexcept
+{
+    // Omit the optional 0x prefix.
+    if (s.size() >= 1 && s[0] == 'Z')
+        s.remove_prefix(1);
+
     T r{};  // The T must have .bytes array. This may be lifted if std::bit_cast is available.
     constexpr auto num_out_bytes = std::size(r.bytes);
     const auto num_in_bytes = s.length() / 2;

--- a/include/evmc/hex.hpp
+++ b/include/evmc/hex.hpp
@@ -135,6 +135,28 @@ constexpr std::optional<T> from_hex(std::string_view s) noexcept
     return r;
 }
 
+/// Decodes hex-encoded string into custom type T with .bytes array of uint8_t.
+///
+/// When the input is smaller than the result type, the result is padded with zeros on the left
+/// (the result bytes of lowest indices are filled with zeros).
+/// TODO: Support optional left alignment.
+template <typename T>
+constexpr std::optional<T> from_hex_z_prefix(std::string_view s) noexcept
+{
+    // Omit the optional 0x prefix.
+    if (s.size() >= 1 && s[0] == 'Z')
+        s.remove_prefix(1);
+
+    T r{};  // The T must have .bytes array. This may be lifted if std::bit_cast is available.
+    constexpr auto num_out_bytes = std::size(r.bytes);
+    const auto num_in_bytes = s.length() / 2;
+    if (num_in_bytes > num_out_bytes)
+        return {};
+    if (!from_hex(s.begin(), s.end(), &r.bytes[num_out_bytes - num_in_bytes]))
+        return {};
+    return r;
+}
+
 /// Decodes hex encoded string to bytes. The whitespace in the input is ignored.
 ///
 /// In case the input is invalid the returned value is std::nullopt.

--- a/include/evmc/hex.hpp
+++ b/include/evmc/hex.hpp
@@ -145,7 +145,7 @@ constexpr std::optional<T> from_prefixed_hex(std::string_view s, std::string_vie
 {
     if (s.size() == 0 || s[0] != prefix[0])
         return {};
-    
+
     // Omit the  prefix.
     s.remove_prefix(prefix.size());
     T r{};  // The T must have .bytes array. This may be lifted if std::bit_cast is available.

--- a/include/evmc/hex.hpp
+++ b/include/evmc/hex.hpp
@@ -141,13 +141,14 @@ constexpr std::optional<T> from_hex(std::string_view s) noexcept
 /// (the result bytes of lowest indices are filled with zeros).
 /// TODO: Support optional left alignment.
 template <typename T>
-constexpr std::optional<T> from_prefixed_hex(std::string_view s, std::string_view prefix) noexcept
+constexpr std::optional<T> from_prefixed_hex(std::string_view s) noexcept
+// constexpr std::optional<T> from_prefixed_hex(std::string_view s, std::string_view prefix) noexcept
 {
-    if (s.size() == 0 || s[0] != prefix[0])
+    if (s.size() == 0 || s[0] != 'Z')
         return {};
 
     // Omit the  prefix.
-    s.remove_prefix(prefix.size());
+    s.remove_prefix(1);
     T r{};  // The T must have .bytes array. This may be lifted if std::bit_cast is available.
     constexpr auto num_out_bytes = std::size(r.bytes);
     const auto num_in_bytes = s.length() / 2;

--- a/include/evmc/mocked_host.hpp
+++ b/include/evmc/mocked_host.hpp
@@ -434,8 +434,8 @@ public:
         record_account_access(addr);
 
         // Accessing precompiled contracts is always warm.
-        if (addr >= 0x0000000000000000000000000000000000000001_address &&
-            addr <= 0x0000000000000000000000000000000000000009_address)
+        if (addr >= Z0000000000000000000000000000000000000001_address &&
+            addr <= Z0000000000000000000000000000000000000009_address)
             return EVMC_ACCESS_WARM;
 
         return already_accessed ? EVMC_ACCESS_WARM : EVMC_ACCESS_COLD;

--- a/include/evmc/mocked_host.hpp
+++ b/include/evmc/mocked_host.hpp
@@ -434,8 +434,8 @@ public:
         record_account_access(addr);
 
         // Accessing precompiled contracts is always warm.
-        if (addr >= Z0000000000000000000000000000000000000001_address &&
-            addr <= Z0000000000000000000000000000000000000009_address)
+        if (addr >= "Z0000000000000000000000000000000000000001"_address &&
+            addr <= "Z0000000000000000000000000000000000000009"_address)
             return EVMC_ACCESS_WARM;
 
         return already_accessed ? EVMC_ACCESS_WARM : EVMC_ACCESS_COLD;

--- a/lib/tooling/run.cpp
+++ b/lib/tooling/run.cpp
@@ -14,7 +14,7 @@ namespace evmc::tooling
 namespace
 {
 /// The address where a new contract is created with --create option.
-constexpr auto create_address = Zc9ea7ed000000000000000000000000000000001_address;
+constexpr auto create_address = "Zc9ea7ed000000000000000000000000000000001"_address;
 
 /// The gas limit for contract creation.
 constexpr auto create_gas = 10'000'000;

--- a/lib/tooling/run.cpp
+++ b/lib/tooling/run.cpp
@@ -14,7 +14,7 @@ namespace evmc::tooling
 namespace
 {
 /// The address where a new contract is created with --create option.
-constexpr auto create_address = 0xc9ea7ed000000000000000000000000000000001_address;
+constexpr auto create_address = Zc9ea7ed000000000000000000000000000000001_address;
 
 /// The gas limit for contract creation.
 constexpr auto create_gas = 10'000'000;

--- a/test/unittests/cpp_test.cpp
+++ b/test/unittests/cpp_test.cpp
@@ -139,10 +139,10 @@ TEST(cpp, std_hash)
     std::fill_n(eb.bytes, sizeof(eb), uint8_t{0xee});
     EXPECT_EQ(std::hash<evmc::bytes32>{}(eb), static_cast<size_t>(0xbb14e5c56b477375));
 
-    const auto rand_address_1 = 0xaa00bb00cc00dd00ee00ff001100220033004400_address;
+    const auto rand_address_1 = Zaa00bb00cc00dd00ee00ff001100220033004400_address;
     EXPECT_EQ(std::hash<evmc::address>{}(rand_address_1), static_cast<size_t>(0x30022347e325524e));
 
-    const auto rand_address_2 = 0x00dd00cc00bb00aa0022001100ff00ee00440033_address;
+    const auto rand_address_2 = Z00dd00cc00bb00aa0022001100ff00ee00440033_address;
     EXPECT_EQ(std::hash<evmc::address>{}(rand_address_2), static_cast<size_t>(0x17f74b6894b0f6b7));
 
     const auto rand_bytes32_1 =
@@ -337,10 +337,10 @@ TEST(cpp, literals)
 {
     using namespace evmc::literals;
 
-    constexpr auto address1 = 0xa0a1a2a3a4a5a6a7a8a9d0d1d2d3d4d5d6d7d8d9_address;
+    constexpr auto address1 = Za0a1a2a3a4a5a6a7a8a9d0d1d2d3d4d5d6d7d8d9_address;
     constexpr auto hash1 =
         0x01020304050607080910a1a2a3a4a5a6a7a8a9b0c1c2c3c4c5c6c7c8c9d0d1d2_bytes32;
-    constexpr auto zero_address = 0x0000000000000000000000000000000000000000_address;
+    constexpr auto zero_address = Z0000000000000000000000000000000000000000_address;
     constexpr auto zero_hash =
         0x0000000000000000000000000000000000000000000000000000000000000000_bytes32;
 
@@ -354,15 +354,15 @@ TEST(cpp, literals)
     static_assert(zero_address == evmc::address{});
     static_assert(zero_hash == evmc::bytes32{});
 
-    static_assert(0x00_address == 0x0000000000000000000000000000000000000000_address);
-    static_assert(0x01_address == 0x0000000000000000000000000000000000000001_address);
-    static_assert(0xf101_address == 0x000000000000000000000000000000000000f101_address);
+    static_assert(Z00_address == Z0000000000000000000000000000000000000000_address);
+    static_assert(Z01_address == Z0000000000000000000000000000000000000001_address);
+    static_assert(Zf101_address == Z000000000000000000000000000000000000f101_address);
 
-    EXPECT_EQ(0x0000000000000000000000000000000000000000_address, evmc::address{});
+    EXPECT_EQ(Z0000000000000000000000000000000000000000_address, evmc::address{});
     EXPECT_EQ(0x0000000000000000000000000000000000000000000000000000000000000000_bytes32,
               evmc::bytes32{});
 
-    auto a1 = 0xa0a1a2a3a4a5a6a7a8a9d0d1d2d3d4d5d6d7d8d9_address;
+    auto a1 = Za0a1a2a3a4a5a6a7a8a9d0d1d2d3d4d5d6d7d8d9_address;
     const evmc::address e1{{{0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9,
                              0xd0, 0xd1, 0xd2, 0xd3, 0xd4, 0xd5, 0xd6, 0xd7, 0xd8, 0xd9}}};
     EXPECT_EQ(a1, e1);
@@ -406,18 +406,18 @@ TEST(cpp, address_from_uint)
     static_assert(address{0xfe00000000000000}.bytes[12] == 0xfe);
 
     EXPECT_EQ(address{0}, address{});
-    EXPECT_EQ(address{0x01}, 0x0000000000000000000000000000000000000001_address);
-    EXPECT_EQ(address{0xff}, 0x00000000000000000000000000000000000000ff_address);
-    EXPECT_EQ(address{0x500}, 0x0000000000000000000000000000000000000500_address);
-    EXPECT_EQ(address{0x8000000000000000}, 0x0000000000000000000000008000000000000000_address);
-    EXPECT_EQ(address{0xc1c2c3c4c5c6c7c8}, 0x000000000000000000000000c1c2c3c4c5c6c7c8_address);
+    EXPECT_EQ(address{0x01}, Z0000000000000000000000000000000000000001_address);
+    EXPECT_EQ(address{0xff}, Z00000000000000000000000000000000000000ff_address);
+    EXPECT_EQ(address{0x500}, Z0000000000000000000000000000000000000500_address);
+    EXPECT_EQ(address{0x8000000000000000}, Z0000000000000000000000008000000000000000_address);
+    EXPECT_EQ(address{0xc1c2c3c4c5c6c7c8}, Z000000000000000000000000c1c2c3c4c5c6c7c8_address);
 }
 
 TEST(cpp, address_to_bytes_view)
 {
     using evmc::operator""_address;
 
-    constexpr auto a = 0xa0a1a2a3a4a5a6a7a8a9b0b1b2b3b4b5b6b7b8b9_address;
+    constexpr auto a = Za0a1a2a3a4a5a6a7a8a9b0b1b2b3b4b5b6b7b8b9_address;
     static_assert(static_cast<evmc::bytes_view>(a).size() == 20);
     const evmc::bytes_view v = a;
     EXPECT_EQ(v, (evmc::bytes{0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9,

--- a/test/unittests/cpp_test.cpp
+++ b/test/unittests/cpp_test.cpp
@@ -139,10 +139,10 @@ TEST(cpp, std_hash)
     std::fill_n(eb.bytes, sizeof(eb), uint8_t{0xee});
     EXPECT_EQ(std::hash<evmc::bytes32>{}(eb), static_cast<size_t>(0xbb14e5c56b477375));
 
-    const auto rand_address_1 = Zaa00bb00cc00dd00ee00ff001100220033004400_address;
+    const auto rand_address_1 = "Zaa00bb00cc00dd00ee00ff001100220033004400"_address;
     EXPECT_EQ(std::hash<evmc::address>{}(rand_address_1), static_cast<size_t>(0x30022347e325524e));
 
-    const auto rand_address_2 = Z00dd00cc00bb00aa0022001100ff00ee00440033_address;
+    const auto rand_address_2 = "Z00dd00cc00bb00aa0022001100ff00ee00440033"_address;
     EXPECT_EQ(std::hash<evmc::address>{}(rand_address_2), static_cast<size_t>(0x17f74b6894b0f6b7));
 
     const auto rand_bytes32_1 =
@@ -337,10 +337,10 @@ TEST(cpp, literals)
 {
     using namespace evmc::literals;
 
-    constexpr auto address1 = Za0a1a2a3a4a5a6a7a8a9d0d1d2d3d4d5d6d7d8d9_address;
+    constexpr auto address1 = "Za0a1a2a3a4a5a6a7a8a9d0d1d2d3d4d5d6d7d8d9"_address;
     constexpr auto hash1 =
         0x01020304050607080910a1a2a3a4a5a6a7a8a9b0c1c2c3c4c5c6c7c8c9d0d1d2_bytes32;
-    constexpr auto zero_address = Z0000000000000000000000000000000000000000_address;
+    constexpr auto zero_address = "Z0000000000000000000000000000000000000000"_address;
     constexpr auto zero_hash =
         0x0000000000000000000000000000000000000000000000000000000000000000_bytes32;
 
@@ -354,15 +354,15 @@ TEST(cpp, literals)
     static_assert(zero_address == evmc::address{});
     static_assert(zero_hash == evmc::bytes32{});
 
-    static_assert(Z00_address == Z0000000000000000000000000000000000000000_address);
-    static_assert(Z01_address == Z0000000000000000000000000000000000000001_address);
-    static_assert(Zf101_address == Z000000000000000000000000000000000000f101_address);
+    static_assert("Z00"_address == "Z0000000000000000000000000000000000000000"_address);
+    static_assert("Z01"_address == "Z0000000000000000000000000000000000000001"_address);
+    static_assert("Zf101"_address == "Z000000000000000000000000000000000000f101"_address);
 
-    EXPECT_EQ(Z0000000000000000000000000000000000000000_address, evmc::address{});
+    EXPECT_EQ("Z0000000000000000000000000000000000000000"_address, evmc::address{});
     EXPECT_EQ(0x0000000000000000000000000000000000000000000000000000000000000000_bytes32,
               evmc::bytes32{});
 
-    auto a1 = Za0a1a2a3a4a5a6a7a8a9d0d1d2d3d4d5d6d7d8d9_address;
+    auto a1 = "Za0a1a2a3a4a5a6a7a8a9d0d1d2d3d4d5d6d7d8d9"_address;
     const evmc::address e1{{{0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9,
                              0xd0, 0xd1, 0xd2, 0xd3, 0xd4, 0xd5, 0xd6, 0xd7, 0xd8, 0xd9}}};
     EXPECT_EQ(a1, e1);
@@ -406,18 +406,18 @@ TEST(cpp, address_from_uint)
     static_assert(address{0xfe00000000000000}.bytes[12] == 0xfe);
 
     EXPECT_EQ(address{0}, address{});
-    EXPECT_EQ(address{0x01}, Z0000000000000000000000000000000000000001_address);
-    EXPECT_EQ(address{0xff}, Z00000000000000000000000000000000000000ff_address);
-    EXPECT_EQ(address{0x500}, Z0000000000000000000000000000000000000500_address);
-    EXPECT_EQ(address{0x8000000000000000}, Z0000000000000000000000008000000000000000_address);
-    EXPECT_EQ(address{0xc1c2c3c4c5c6c7c8}, Z000000000000000000000000c1c2c3c4c5c6c7c8_address);
+    EXPECT_EQ(address{0x01}, "Z0000000000000000000000000000000000000001"_address);
+    EXPECT_EQ(address{0xff}, "Z00000000000000000000000000000000000000ff"_address);
+    EXPECT_EQ(address{0x500}, "Z0000000000000000000000000000000000000500"_address);
+    EXPECT_EQ(address{0x8000000000000000}, "Z0000000000000000000000008000000000000000"_address);
+    EXPECT_EQ(address{0xc1c2c3c4c5c6c7c8}, "Z000000000000000000000000c1c2c3c4c5c6c7c8"_address);
 }
 
 TEST(cpp, address_to_bytes_view)
 {
     using evmc::operator""_address;
 
-    constexpr auto a = Za0a1a2a3a4a5a6a7a8a9b0b1b2b3b4b5b6b7b8b9_address;
+    constexpr auto a = "Za0a1a2a3a4a5a6a7a8a9b0b1b2b3b4b5b6b7b8b9"_address;
     static_assert(static_cast<evmc::bytes_view>(a).size() == 20);
     const evmc::bytes_view v = a;
     EXPECT_EQ(v, (evmc::bytes{0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9,

--- a/test/unittests/example_vm_test.cpp
+++ b/test/unittests/example_vm_test.cpp
@@ -153,7 +153,8 @@ TEST_F(example_vm, call)
     EXPECT_EQ(host.recorded_calls[0].gas, 3);
     EXPECT_EQ(host.recorded_calls[0].value,
               0x0000000000000000000000000000000000000000000000000000000000000003_bytes32);
-    EXPECT_EQ(host.recorded_calls[0].recipient, "Z0000000000000000000000000000000000000003"_address);
+    EXPECT_EQ(host.recorded_calls[0].recipient,
+              "Z0000000000000000000000000000000000000003"_address);
     EXPECT_EQ(host.recorded_calls[0].input_size, size_t{3});
 }
 

--- a/test/unittests/example_vm_test.cpp
+++ b/test/unittests/example_vm_test.cpp
@@ -37,8 +37,8 @@ protected:
 
     example_vm() noexcept
     {
-        msg.sender = 0x5000000000000000000000000000000000000005_address;
-        msg.recipient = 0xd00000000000000000000000000000000000000d_address;
+        msg.sender = Z5000000000000000000000000000000000000005_address;
+        msg.recipient = Zd00000000000000000000000000000000000000d_address;
     }
 
     evmc::Result execute_in_example_vm(int64_t gas,
@@ -153,7 +153,7 @@ TEST_F(example_vm, call)
     EXPECT_EQ(host.recorded_calls[0].gas, 3);
     EXPECT_EQ(host.recorded_calls[0].value,
               0x0000000000000000000000000000000000000000000000000000000000000003_bytes32);
-    EXPECT_EQ(host.recorded_calls[0].recipient, 0x0000000000000000000000000000000000000003_address);
+    EXPECT_EQ(host.recorded_calls[0].recipient, Z0000000000000000000000000000000000000003_address);
     EXPECT_EQ(host.recorded_calls[0].input_size, size_t{3});
 }
 

--- a/test/unittests/example_vm_test.cpp
+++ b/test/unittests/example_vm_test.cpp
@@ -37,8 +37,8 @@ protected:
 
     example_vm() noexcept
     {
-        msg.sender = Z5000000000000000000000000000000000000005_address;
-        msg.recipient = Zd00000000000000000000000000000000000000d_address;
+        msg.sender = "Z5000000000000000000000000000000000000005"_address;
+        msg.recipient = "Zd00000000000000000000000000000000000000d"_address;
     }
 
     evmc::Result execute_in_example_vm(int64_t gas,
@@ -153,7 +153,7 @@ TEST_F(example_vm, call)
     EXPECT_EQ(host.recorded_calls[0].gas, 3);
     EXPECT_EQ(host.recorded_calls[0].value,
               0x0000000000000000000000000000000000000000000000000000000000000003_bytes32);
-    EXPECT_EQ(host.recorded_calls[0].recipient, Z0000000000000000000000000000000000000003_address);
+    EXPECT_EQ(host.recorded_calls[0].recipient, "Z0000000000000000000000000000000000000003"_address);
     EXPECT_EQ(host.recorded_calls[0].input_size, size_t{3});
 }
 

--- a/test/unittests/hex_test.cpp
+++ b/test/unittests/hex_test.cpp
@@ -129,6 +129,7 @@ TEST(hex, from_hex_to_custom_type)
     EXPECT_FALSE(evmc::from_hex<X>("0x0000000000"));
 }
 
+/*
 TEST(hex, from_prefixed_hex_to_custom_type)
 {
     struct X
@@ -163,3 +164,4 @@ TEST(hex, from_prefixed_hex_to_custom_type)
     // The result type is too small for the input.
     EXPECT_FALSE(evmc::from_prefixed_hex<X>("Z0000000000", 'Z'));
 }
+*/

--- a/test/unittests/hex_test.cpp
+++ b/test/unittests/hex_test.cpp
@@ -139,7 +139,8 @@ TEST(hex, from_prefixed_hex_to_custom_type)
         return evmc::hex({evmc::from_prefixed_hex<X>(in, 'Z').value().bytes, sizeof(X)});
     };
 
-    static_assert(evmc::from_prefixed_hex<X>("Z01", 'Z').value().bytes[3] == 0x01);  // Works in constexpr.
+    static_assert(evmc::from_prefixed_hex<X>("Z01", 'Z').value().bytes[3] == 0x01);  // Works in
+                                                                                     // constexpr.
 
     EXPECT_EQ(test("Z01020304"), "01020304");
     EXPECT_EQ(test("Z010203"), "00010203");

--- a/test/unittests/hex_test.cpp
+++ b/test/unittests/hex_test.cpp
@@ -25,6 +25,7 @@ TEST(hex, hex_of_bytes)
     EXPECT_EQ(hex({nullptr, 0}), "");
 }
 
+// TODO(rgeraldes24): add more tests from_hex_z_prefix
 TEST(hex, from_hex)
 {
     EXPECT_EQ(from_hex(""), bytes{});

--- a/test/unittests/hex_test.cpp
+++ b/test/unittests/hex_test.cpp
@@ -25,7 +25,6 @@ TEST(hex, hex_of_bytes)
     EXPECT_EQ(hex({nullptr, 0}), "");
 }
 
-// TODO(rgeraldes24): add more tests from_hex_z_prefix
 TEST(hex, from_hex)
 {
     EXPECT_EQ(from_hex(""), bytes{});
@@ -128,4 +127,38 @@ TEST(hex, from_hex_to_custom_type)
     // The result type is too small for the input.
     EXPECT_FALSE(evmc::from_hex<X>("0000000000"));
     EXPECT_FALSE(evmc::from_hex<X>("0x0000000000"));
+}
+
+TEST(hex, from_prefixed_hex_to_custom_type)
+{
+    struct X
+    {
+        uint8_t bytes[4];
+    };
+    constexpr auto test = [](std::string_view in) {
+        return evmc::hex({evmc::from_prefixed_hex<X>(in, 'Z').value().bytes, sizeof(X)});
+    };
+
+    static_assert(evmc::from_prefixed_hex<X>("Z01", 'Z').value().bytes[3] == 0x01);  // Works in constexpr.
+
+    EXPECT_EQ(test("Z01020304"), "01020304");
+    EXPECT_EQ(test("Z010203"), "00010203");
+    EXPECT_EQ(test("Z0102"), "00000102");
+    EXPECT_EQ(test("Z01"), "00000001");
+    EXPECT_EQ(test("Z"), "00000000");
+
+    EXPECT_FALSE(evmc::from_prefixed_hex<X>("", 'Z'));
+    EXPECT_FALSE(evmc::from_prefixed_hex<X>("0", 'Z'));
+    EXPECT_FALSE(evmc::from_prefixed_hex<X>("1", 'Z'));
+    EXPECT_FALSE(evmc::from_prefixed_hex<X>("Z ", 'Z'));
+    EXPECT_FALSE(evmc::from_prefixed_hex<X>("Zf", 'Z'));
+    EXPECT_FALSE(evmc::from_prefixed_hex<X>("Z 00", 'Z'));
+    EXPECT_FALSE(evmc::from_prefixed_hex<X>("1x", 'Z'));
+    EXPECT_FALSE(evmc::from_prefixed_hex<X>("1Z0", 'Z'));
+    EXPECT_FALSE(evmc::from_prefixed_hex<X>("fx", 'Z'));
+    EXPECT_FALSE(evmc::from_prefixed_hex<X>("fZ0", 'Z'));
+    EXPECT_FALSE(evmc::from_prefixed_hex<X>("f1f2f3f4", 'Z'));
+
+    // The result type is too small for the input.
+    EXPECT_FALSE(evmc::from_prefixed_hex<X>("Z0000000000", 'Z'));
 }

--- a/test/unittests/mocked_host_test.cpp
+++ b/test/unittests/mocked_host_test.cpp
@@ -22,7 +22,7 @@ TEST(mocked_host, mocked_account)
 TEST(mocked_host, storage)
 {
     const auto addr1 = evmc::address{};
-    const auto addr2 = Z2000000000000000000000000000000000000000_address;
+    const auto addr2 = "Z2000000000000000000000000000000000000000"_address;
     const auto val1 = evmc::bytes32{};
     const auto val2 = 0x2000000000000000000000000000000000000000000000000102030405060708_bytes32;
     const auto val3 = 0x1000000000000000000000000000000000000000000000000000000000000000_bytes32;
@@ -74,7 +74,7 @@ TEST(mocked_host, storage)
 
 TEST(mocked_host, storage_update_scenarios)
 {
-    static constexpr auto addr = Zff_address;
+    static constexpr auto addr = "Zff"_address;
     static constexpr auto key = 0xfe_bytes32;
 
     static constexpr auto execute_scenario = [](const evmc::bytes32& original,

--- a/test/unittests/mocked_host_test.cpp
+++ b/test/unittests/mocked_host_test.cpp
@@ -22,7 +22,7 @@ TEST(mocked_host, mocked_account)
 TEST(mocked_host, storage)
 {
     const auto addr1 = evmc::address{};
-    const auto addr2 = 0x2000000000000000000000000000000000000000_address;
+    const auto addr2 = Z2000000000000000000000000000000000000000_address;
     const auto val1 = evmc::bytes32{};
     const auto val2 = 0x2000000000000000000000000000000000000000000000000102030405060708_bytes32;
     const auto val3 = 0x1000000000000000000000000000000000000000000000000000000000000000_bytes32;
@@ -74,7 +74,7 @@ TEST(mocked_host, storage)
 
 TEST(mocked_host, storage_update_scenarios)
 {
-    static constexpr auto addr = 0xff_address;
+    static constexpr auto addr = Zff_address;
     static constexpr auto key = 0xfe_bytes32;
 
     static constexpr auto execute_scenario = [](const evmc::bytes32& original,


### PR DESCRIPTION
## TESTS

Configure project/build binaries: 

```
$ cmake -S . -B build -DEVMC_TESTING=ON
$ cmake --build build -- -j4
```

**unit tests**

```
$ build/bin/evmc-unittests

[----------] Global test environment tear-down
[==========] 102 tests from 10 test suites ran. (1174 ms total)
[  PASSED  ] 102 tests.
```

**circle ci pipeline**

<img width="428" alt="image" src="https://github.com/user-attachments/assets/7fe2f22d-9619-4dc8-85a9-9b47cd45ce93">
