### PR TITLE
Add new address format: z-prefixed hex string part 2

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -467,8 +467,8 @@ workflows:
       - lint
       - build-clang-coverage
       # TODO(now.youtrack.cloud/issue/TE-16)
-      - build-gcc-sanitizers
-      - build-clang-sanitizers
+      #- build-gcc-sanitizers
+      #- build-clang-sanitizers
       - build-clang9-asan
       - build-gcc-min
       - build-clang-min

--- a/circle.yml
+++ b/circle.yml
@@ -463,6 +463,7 @@ workflows:
       - build-clang9-asan
       - build-gcc-min
       - build-clang-min
+      - build-gcc-32bit
       - build-cmake-min
       - build-macos
       - build-windows

--- a/circle.yml
+++ b/circle.yml
@@ -467,8 +467,8 @@ workflows:
       - lint
       - build-clang-coverage
       # TODO(now.youtrack.cloud/issue/TE-16)
-      #- build-gcc-sanitizers
-      #- build-clang-sanitizers
+      - build-gcc-sanitizers
+      - build-clang-sanitizers
       - build-clang9-asan
       - build-gcc-min
       - build-clang-min

--- a/circle.yml
+++ b/circle.yml
@@ -472,7 +472,7 @@ workflows:
       - build-clang9-asan
       - build-gcc-min
       - build-clang-min
-      - build-gcc-32bit
+      #- build-gcc-32bit
       - build-cmake-min
       - build-macos
       - build-windows

--- a/circle.yml
+++ b/circle.yml
@@ -283,6 +283,15 @@ jobs:
       - build
       - test
 
+  build-gcc-32bit:
+    docker:
+      - image: ethereum/cpp-build-env:17-gcc-11-multilib
+    steps:
+      - checkout
+      - build:
+          toolchain: cxx11-32bit
+      - test
+
   build-cmake-min:
     docker:
       - image: cimg/base:stable-20.04

--- a/circle.yml
+++ b/circle.yml
@@ -472,7 +472,7 @@ workflows:
       - build-clang9-asan
       - build-gcc-min
       - build-clang-min
-      #- build-gcc-32bit
+      - build-gcc-32bit
       - build-cmake-min
       - build-macos
       - build-windows

--- a/circle.yml
+++ b/circle.yml
@@ -283,15 +283,6 @@ jobs:
       - build
       - test
 
-  build-gcc-32bit:
-    docker:
-      - image: ethereum/cpp-build-env:17-gcc-11-multilib
-    steps:
-      - checkout
-      - build:
-          toolchain: cxx11-32bit
-      - test
-
   build-cmake-min:
     docker:
       - image: cimg/base:stable-20.04
@@ -347,40 +338,6 @@ jobs:
           command: |
             $ErrorActionPreference = "Stop"
             & 'C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\Launch-VsDevShell.ps1' -Arch amd64
-            cmake --build ~/build --target test
-
-  build-windows-32bit:
-    executor: win/server-2022
-    environment:
-      CMAKE_BUILD_TYPE: Release
-    steps:
-      - checkout
-      - run:
-          name: "Setup environment (bash)"
-          shell: bash
-          command: |
-            echo 'export PATH=$PATH:"/c/Program Files/Microsoft Visual Studio/2022/Community/Common7/IDE/CommonExtensions/Microsoft/CMake/CMake/bin"' >> $BASH_ENV
-      - run:
-          name: 'Configure'
-          shell: powershell
-          command: |
-            $ErrorActionPreference = "Stop"
-            & 'C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\Launch-VsDevShell.ps1' -Arch x86
-            which cmake
-            cmake -S . -B ~/build -G Ninja -DCMAKE_COMPILE_WARNING_AS_ERROR=TRUE -DCMAKE_INSTALL_PREFIX=C:\install -DEVMC_TESTING=ON
-      - run:
-          name: 'Build'
-          shell: powershell
-          command: |
-            $ErrorActionPreference = "Stop"
-            & 'C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\Launch-VsDevShell.ps1' -Arch x86
-            cmake --build ~/build
-      - run:
-          name: 'Test'
-          shell: powershell
-          command: |
-            $ErrorActionPreference = "Stop"
-            & 'C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\Launch-VsDevShell.ps1' -Arch x86
             cmake --build ~/build --target test
 
   bindings-go-latest:
@@ -506,11 +463,9 @@ workflows:
       - build-clang9-asan
       - build-gcc-min
       - build-clang-min
-      - build-gcc-32bit
       - build-cmake-min
       - build-macos
       - build-windows
-      - build-windows-32bit
       - bindings-go-latest:
           filters:
             tags:

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -318,13 +318,13 @@ constexpr address operator""_address(const char* s, unsigned long) noexcept
     return parse<address>(s, "Z");
 }
 
-#endif
-
 /// Literal for evmc::address.
 constexpr address operator""_address(const char* s, unsigned int) noexcept
 {
     return parse<address>(s, "Z");
 }
+
+#endif
 
 /// Literal for evmc::bytes32.
 constexpr bytes32 operator""_bytes32(const char* s) noexcept

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -303,22 +303,28 @@ constexpr T parse(std::string_view s, std::string_view prefix) noexcept
     return from_prefixed_hex<T>(s, prefix).value();
 }
 
+// #if _WIN32
+// /// Literal for evmc::address.
+// constexpr address operator""_address(const char* s, size_t) noexcept
+// {
+//     return parse<address>(s, "Z");
+// }
 
-#if _WIN32
+// #else
+// /// Literal for evmc::address.
+// constexpr address operator""_address(const char* s, unsigned long) noexcept
+// {
+//     return parse<address>(s, "Z");
+// }
+
+// #endif
+
 /// Literal for evmc::address.
-constexpr address operator""_address(const char* s, size_t) noexcept
+constexpr address operator""_address(const char* s, uint_t) noexcept
 {
     return parse<address>(s, "Z");
 }
 
-#else
-/// Literal for evmc::address.
-constexpr address operator""_address(const char* s, unsigned long) noexcept
-{
-    return parse<address>(s, "Z");
-}
-
-#endif
 
 /// Literal for evmc::bytes32.
 constexpr bytes32 operator""_bytes32(const char* s) noexcept

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -303,6 +303,7 @@ constexpr T parse(std::string_view s, std::string_view prefix) noexcept
     return from_prefixed_hex<T>(s, prefix).value();
 }
 
+/// Literal for evmc::address.
 constexpr address operator""_address(const char* s, unsigned long) noexcept
 {
     return parse<address>(s, "Z");

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -303,11 +303,20 @@ constexpr T parse(std::string_view s, std::string_view prefix) noexcept
     return from_prefixed_hex<T>(s, prefix).value();
 }
 
+#if _WIN32
 /// Literal for evmc::address.
-constexpr address operator""_address(const char* s) noexcept
+constexpr address operator""_address(const char* s, size_t) noexcept
 {
     return parse<address>(s, "Z");
 }
+#else
+/// Literal for evmc::address.
+constexpr address operator""_address(const char* s, unsigned long) noexcept
+{
+    return parse<address>(s, "Z");
+}
+#endif
+
 
 /// Literal for evmc::bytes32.
 constexpr bytes32 operator""_bytes32(const char* s) noexcept

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -313,7 +313,7 @@ constexpr address operator""_address(const char* s, size_t) noexcept
 
 #else
 /// Literal for evmc::address.
-constexpr address operator""_address(const char* s, unsigned int) noexcept
+constexpr address operator""_address(const char* s, unsigned long) noexcept
 {
     return parse<address>(s, "Z");
 }

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -313,12 +313,6 @@ constexpr address operator""_address(const char* s, size_t) noexcept
 
 #else
 /// Literal for evmc::address.
-constexpr address operator""_address(const char* s, unsigned long) noexcept
-{
-    return parse<address>(s, "Z");
-}
-
-/// Literal for evmc::address.
 constexpr address operator""_address(const char* s, unsigned int) noexcept
 {
     return parse<address>(s, "Z");

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -313,7 +313,7 @@ constexpr address operator""_address(const char* s, size_t) noexcept
 
 #else
 /// Literal for evmc::address.
-constexpr address operator""_address(const char* s, uint64_t) noexcept
+constexpr address operator""_address(const char* s, uint32_t) noexcept
 {
     return parse<address>(s, "Z");
 }

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -304,7 +304,7 @@ constexpr T parse(std::string_view s, std::string_view prefix) noexcept
 }
 
 /// Literal for evmc::address.
-constexpr address operator""_address(const char* s, uint64_t) noexcept
+constexpr address operator""_address(const char* s) noexcept
 {
     return parse<address>(s, "Z");
 }

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -303,11 +303,22 @@ constexpr T parse(std::string_view s, std::string_view prefix) noexcept
     return from_prefixed_hex<T>(s, prefix).value();
 }
 
+
+#if _WIN32
+/// Literal for evmc::address.
+constexpr address operator""_address(const char* s, size_t) noexcept
+{
+    return parse<address>(s, "Z");
+}
+
+#else
 /// Literal for evmc::address.
 constexpr address operator""_address(const char* s, unsigned long) noexcept
 {
     return parse<address>(s, "Z");
 }
+
+#endif
 
 
 /// Literal for evmc::bytes32.

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -309,7 +309,6 @@ constexpr address operator""_address(const char* s, size_t) noexcept
     return parse<address>(s, "Z");
 }
 
-
 /// Literal for evmc::bytes32.
 constexpr bytes32 operator""_bytes32(const char* s) noexcept
 {

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -304,7 +304,7 @@ constexpr T parse(std::string_view s, std::string_view prefix) noexcept
 }
 
 /// Literal for evmc::address.
-constexpr address operator""_address(const char* s, unsigned long int) noexcept
+constexpr address operator""_address(const char* s, unsigned long long _) noexcept
 {
     return parse<address>(s, "Z");
 }

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -304,7 +304,7 @@ constexpr T parse(std::string_view s, std::string_view prefix) noexcept
 }
 
 /// Literal for evmc::address.
-constexpr address operator""_address(const char* s, unsigned long long _) noexcept
+constexpr address operator""_address(const char* s, uint64_t) noexcept
 {
     return parse<address>(s, "Z");
 }

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -320,7 +320,7 @@ constexpr T parse(std::string_view s, std::string_view prefix) noexcept
 // #endif
 
 /// Literal for evmc::address.
-constexpr address operator""_address(const char* s, uint_t) noexcept
+constexpr address operator""_address(const char* s, int) noexcept
 {
     return parse<address>(s, "Z");
 }

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -313,7 +313,7 @@ constexpr address operator""_address(const char* s, size_t) noexcept
 
 #else
 /// Literal for evmc::address.
-constexpr address operator""_address(const char* s, uint32_t) noexcept
+constexpr address operator""_address(const char* s, unsigned long) noexcept
 {
     return parse<address>(s, "Z");
 }

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -320,7 +320,7 @@ constexpr T parse(std::string_view s, std::string_view prefix) noexcept
 // #endif
 
 /// Literal for evmc::address.
-constexpr address operator""_address(const char* s, int) noexcept
+constexpr address operator""_address(const char* s, size_t) noexcept
 {
     return parse<address>(s, "Z");
 }

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -313,7 +313,7 @@ constexpr address operator""_address(const char* s, size_t) noexcept
 
 #else
 /// Literal for evmc::address.
-constexpr address operator""_address(const char* s, unsigned long) noexcept
+constexpr address operator""_address(const char* s, uint64_t) noexcept
 {
     return parse<address>(s, "Z");
 }

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -303,23 +303,7 @@ constexpr T parse(std::string_view s, std::string_view prefix) noexcept
     return from_prefixed_hex<T>(s, prefix).value();
 }
 
-/*
-#if _WIN32
-/// Literal for evmc::address.
-constexpr address operator""_address(const char* s, size_t) noexcept
-{
-    return parse<address>(s, "Z");
-}
-#else
-/// Literal for evmc::address.
-constexpr address operator""_address(const char* s, unsigned long) noexcept
-{
-    return parse<address>(s, "Z");
-}
-#endif
-*/
-
-constexpr address operator""_address(const char* s, size_t) noexcept
+constexpr address operator""_address(const char* s, size_t _) noexcept
 {
     return parse<address>(s, "Z");
 }

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -320,6 +320,11 @@ constexpr address operator""_address(const char* s, unsigned long) noexcept
 
 #endif
 
+/// Literal for evmc::address.
+constexpr address operator""_address(const char* s, unsigned int) noexcept
+{
+    return parse<address>(s, "Z");
+}
 
 /// Literal for evmc::bytes32.
 constexpr bytes32 operator""_bytes32(const char* s) noexcept

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -304,7 +304,7 @@ constexpr T parse(std::string_view s, std::string_view prefix) noexcept
 }
 
 /// Literal for evmc::address.
-constexpr address operator""_address(const char* s, size_t) noexcept
+constexpr address operator""_address(const char* s, unsigned long) noexcept
 {
     return parse<address>(s, "Z");
 }

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -303,7 +303,7 @@ constexpr T parse(std::string_view s, std::string_view prefix) noexcept
     return from_prefixed_hex<T>(s, prefix).value();
 }
 
-constexpr address operator""_address(const char* s, size_t _) noexcept
+constexpr address operator""_address(const char* s, unsigned long) noexcept
 {
     return parse<address>(s, "Z");
 }

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -303,6 +303,7 @@ constexpr T parse(std::string_view s, std::string_view prefix) noexcept
     return from_prefixed_hex<T>(s, prefix).value();
 }
 
+/*
 #if _WIN32
 /// Literal for evmc::address.
 constexpr address operator""_address(const char* s, size_t) noexcept
@@ -316,6 +317,12 @@ constexpr address operator""_address(const char* s, unsigned long) noexcept
     return parse<address>(s, "Z");
 }
 #endif
+*/
+
+constexpr address operator""_address(const char* s, size_t) noexcept
+{
+    return parse<address>(s, "Z");
+}
 
 
 /// Literal for evmc::bytes32.

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -304,7 +304,7 @@ constexpr T parse(std::string_view s, std::string_view prefix) noexcept
 }
 
 /// Literal for evmc::address.
-constexpr address operator""_address(const char* s, unsigned long) noexcept
+constexpr address operator""_address(const char* s, unsigned long int) noexcept
 {
     return parse<address>(s, "Z");
 }

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -303,22 +303,6 @@ constexpr T parse(std::string_view s, std::string_view prefix) noexcept
     return from_prefixed_hex<T>(s, prefix).value();
 }
 
-// #if _WIN32
-// /// Literal for evmc::address.
-// constexpr address operator""_address(const char* s, size_t) noexcept
-// {
-//     return parse<address>(s, "Z");
-// }
-
-// #else
-// /// Literal for evmc::address.
-// constexpr address operator""_address(const char* s, unsigned long) noexcept
-// {
-//     return parse<address>(s, "Z");
-// }
-
-// #endif
-
 /// Literal for evmc::address.
 constexpr address operator""_address(const char* s, size_t) noexcept
 {

--- a/include/evmc/hex.hpp
+++ b/include/evmc/hex.hpp
@@ -108,12 +108,15 @@ inline bool validate_hex(std::string_view hex) noexcept
 template <typename T>
 constexpr std::optional<T> from_prefixed_hex(std::string_view s, std::string_view prefix) noexcept
 {
-    if (s.empty() || (s.rfind(prefix, 0) != 0))
+    if (!s.empty())
     {
-        return {};
+        // NOTE(rgeraldes24): non-empty string must have the prefix
+        if (s.rfind(prefix, 0) != 0)
+            return {};
+        else
+            s.remove_prefix(prefix.size());
     }
 
-    s.remove_prefix(prefix.size());
     T r{};  // The T must have .bytes array. This may be lifted if std::bit_cast is available.
     constexpr auto num_out_bytes = std::size(r.bytes);
     const auto num_in_bytes = s.length() / 2;

--- a/include/evmc/hex.hpp
+++ b/include/evmc/hex.hpp
@@ -107,7 +107,6 @@ inline bool validate_hex(std::string_view hex) noexcept
 /// TODO: Support optional left alignment.
 template <typename T>
 constexpr std::optional<T> from_prefixed_hex(std::string_view s, std::string_view prefix) noexcept
-
 {
     if (!s.empty())
     {

--- a/include/evmc/hex.hpp
+++ b/include/evmc/hex.hpp
@@ -108,11 +108,12 @@ inline bool validate_hex(std::string_view hex) noexcept
 template <typename T>
 constexpr std::optional<T> from_prefixed_hex(std::string_view s, std::string_view prefix) noexcept
 {
-    if (s.empty() || s.rfind(prefix, 0) != 0)
+    if (!s.empty() && s.rfind(prefix, 0) != 0)
         return {};
 
-    // Omit the prefix.
-    s.remove_prefix(prefix.size());
+    // Omit the prefix
+    if (!s.empty())
+        s.remove_prefix(prefix.size());
     T r{};  // The T must have .bytes array. This may be lifted if std::bit_cast is available.
     constexpr auto num_out_bytes = std::size(r.bytes);
     const auto num_in_bytes = s.length() / 2;

--- a/include/evmc/hex.hpp
+++ b/include/evmc/hex.hpp
@@ -108,15 +108,12 @@ inline bool validate_hex(std::string_view hex) noexcept
 template <typename T>
 constexpr std::optional<T> from_prefixed_hex(std::string_view s, std::string_view prefix) noexcept
 {
-    if (!s.empty())
+    if (s.empty() || (s.rfind(prefix, 0) != 0)) 
     {
-        // NOTE(rgeraldes24): non-empty string must have the prefix
-        if (s.rfind(prefix, 0) != 0)
-            return {};
-        else
-            s.remove_prefix(prefix.size());
+        return {};
     }
 
+    s.remove_prefix(prefix.size());
     T r{};  // The T must have .bytes array. This may be lifted if std::bit_cast is available.
     constexpr auto num_out_bytes = std::size(r.bytes);
     const auto num_in_bytes = s.length() / 2;

--- a/include/evmc/hex.hpp
+++ b/include/evmc/hex.hpp
@@ -108,7 +108,7 @@ inline bool validate_hex(std::string_view hex) noexcept
 template <typename T>
 constexpr std::optional<T> from_prefixed_hex(std::string_view s, std::string_view prefix) noexcept
 {
-    if (s.empty() || (s.rfind(prefix, 0) != 0)) 
+    if (s.empty() || (s.rfind(prefix, 0) != 0))
     {
         return {};
     }

--- a/include/evmc/hex.hpp
+++ b/include/evmc/hex.hpp
@@ -107,13 +107,16 @@ inline bool validate_hex(std::string_view hex) noexcept
 /// TODO: Support optional left alignment.
 template <typename T>
 constexpr std::optional<T> from_prefixed_hex(std::string_view s, std::string_view prefix) noexcept
-{
-    if (!s.empty() && s.rfind(prefix, 0) != 0)
-        return {};
 
-    // Omit the prefix
-    if (!s.empty())
-        s.remove_prefix(prefix.size());
+{
+    if (!s.empty()) {
+        // NOTE(rgeraldes24): non-empty string must have the prefix
+        if (s.rfind(prefix, 0) != 0)
+            return {};
+        else 
+            s.remove_prefix(prefix.size());
+    }
+        
     T r{};  // The T must have .bytes array. This may be lifted if std::bit_cast is available.
     constexpr auto num_out_bytes = std::size(r.bytes);
     const auto num_in_bytes = s.length() / 2;

--- a/include/evmc/hex.hpp
+++ b/include/evmc/hex.hpp
@@ -109,14 +109,15 @@ template <typename T>
 constexpr std::optional<T> from_prefixed_hex(std::string_view s, std::string_view prefix) noexcept
 
 {
-    if (!s.empty()) {
+    if (!s.empty())
+    {
         // NOTE(rgeraldes24): non-empty string must have the prefix
         if (s.rfind(prefix, 0) != 0)
             return {};
-        else 
+        else
             s.remove_prefix(prefix.size());
     }
-        
+
     T r{};  // The T must have .bytes array. This may be lifted if std::bit_cast is available.
     constexpr auto num_out_bytes = std::size(r.bytes);
     const auto num_in_bytes = s.length() / 2;

--- a/include/evmc/hex.hpp
+++ b/include/evmc/hex.hpp
@@ -108,7 +108,7 @@ inline bool validate_hex(std::string_view hex) noexcept
 template <typename T>
 constexpr std::optional<T> from_prefixed_hex(std::string_view s, std::string_view prefix) noexcept
 {
-    if (s.size() == 0 || s.rfind(prefix, 0) != 0)
+    if (s.empty() || s.rfind(prefix, 0) != 0)
         return {};
 
     // Omit the prefix.

--- a/test/unittests/hex_test.cpp
+++ b/test/unittests/hex_test.cpp
@@ -146,7 +146,6 @@ TEST(hex, from_prefixed_hex_to_custom_type)
     EXPECT_EQ(test("Z0102"), "00000102");
     EXPECT_EQ(test("Z01"), "00000001");
     EXPECT_EQ(test("Z"), "00000000");
-    EXPECT_FALSE(evmc::from_prefixed_hex<X>("", "Z"));
     EXPECT_FALSE(evmc::from_prefixed_hex<X>("0", "Z"));
     EXPECT_FALSE(evmc::from_prefixed_hex<X>("1", "Z"));
     EXPECT_FALSE(evmc::from_prefixed_hex<X>("Z ", "Z"));


### PR DESCRIPTION
## DESC 

- Removes support for 32bit-windows (no longer supported by evmone)
- Reviews 'from_prefixed_hex' function to handle the empty string case as before(evmone tests)

## TESTS

Configure project/build binaries: 

```
$ cmake -S . -B build -DEVMC_TESTING=ON
$ cmake --build build -- -j4
```

**circle ci pipeline**

<img width="585" alt="image" src="https://github.com/user-attachments/assets/644926fc-bd2a-4d2d-92d3-dbc817bb8594">
